### PR TITLE
Changes signup to autofill from Google OAuth

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,20 +3,21 @@ class UsersController < ApplicationController
   skip_before_filter :authenticate, :only => ['new', 'create']
   before_filter :check_is_user, :except => ['new', 'create', 'show']
   before_filter :set_user, :except => ['new', 'create']
-  
+
   def show
     @user = User.find_by_id(params[:id])
   end
-  
+
   def new
     @user = User.new
     session[:user_id] = @user.id
+    @user_email = session[:user_email] = params[:user_email]
     render 'new'
   end
-  
+
   def create
     @user = User.new(user_params)
-    
+
     if @user.save
       #EmailStudents.welcome_email(@user).deliver_later
 
@@ -30,7 +31,7 @@ class UsersController < ApplicationController
 
   def start_team
     @user.leave_team if !(@user.team.nil?)
-    
+
     @team = Team.create!(:passcode => Team.generate_hash, :approved => false, :submitted => false)
 
     @user.team = @team
@@ -43,15 +44,15 @@ class UsersController < ApplicationController
     @team = Team.find_by_passcode(@passcode)
     @team ||= Team.new()
     return redirect_to without_team_path, :notice => "Unable to join team" if @passcode.empty? or !(@team.can_join?)
-    
+
     @user.leave_team if !(@user.team.nil?)
-    
+
     @user.team = @team
     @team.users << @user
     @team.withdraw_submission
-    
+
     @team.send_submission_reminder_email if @team.eligible?
-     
+
     redirect_to team_path(:id=>@team.id)
   end
 
@@ -68,7 +69,7 @@ class UsersController < ApplicationController
       return redirect_to session.delete(:return_to), :notice => 'Permission denied'
     end
   end
-  
+
   def set_user
     @user = User.find_by_id session[:user_id]
   end

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -8,7 +8,7 @@
             <%= link_to "Log In", "/auth/google_oauth2", {id: "log_in", class: "btn btn-default"}  %>
             <br>
             <br>
-            <%= link_to "Sign Up", new_user_path, {method: :get, class: "btn btn-default"} %>
+            <%= link_to "Sign Up", "/auth/google_oauth2", {id: "sign_up", class: "btn btn-default"} %>
             <br>
             <br>
             <br>

--- a/app/views/shared/_basic_info.html.erb
+++ b/app/views/shared/_basic_info.html.erb
@@ -13,6 +13,6 @@
     <%= f.label :name, class: "col-lg-2 control-label" %> <br>
     <%= f.text_field :name, class: "form-control" %>
     <%= f.label :email, class: "col-lg-2 control-label" %> <br>
-    <%= f.text_field :email, {class: "form-control", :readonly => ((@user.nil? or @user.id.nil?) and (@admin.nil? or @admin.id.nil?)) ? false : true} %>
+    <%= f.text_field :email, {class: "form-control", :readonly => (((@user.nil? or @user.id.nil?) and (@admin.nil? or @admin.id.nil?)) and !@user_email) ? false : true} %>
     <p class="text-danger"> <strong> Warning: </strong> Please do not use any email aliases - you will not be able to sign in. You must be able to sign into CalNet and/or Gmail using the email provided here.</p>
 </div>


### PR DESCRIPTION
Redirects to Google OAuth in order to grab the proper email address and blocks the user from changing the email. This is to prevent the user from changing the email to an alias.